### PR TITLE
Dev auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+.env

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -2,6 +2,16 @@
 import { store } from '../store';
 import { useRouter } from 'vue-router';
 const router = useRouter();
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_apiKey,
+  authDomain: "maths-qs.firebaseapp.com",
+  projectId: "maths-qs",
+  storageBucket: "maths-qs.appspot.com",
+  messagingSenderId: import.meta.env.VITE_messagingSenderId,
+  appId: import.meta.env.VITE_appId,
+  measurementId: import.meta.env.VITE_measurementId
+};
+// console.log('From Login: ', firebaseConfig)
 const login = () => {
     store.commit('login')
     store.commit('changeUser', 'Guest')

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -9,12 +9,13 @@ const firebaseConfig = {
   storageBucket: "maths-qs.appspot.com",
   messagingSenderId: import.meta.env.VITE_messagingSenderId,
   appId: import.meta.env.VITE_appId,
-  measurementId: import.meta.env.VITE_measurementId
+  measurementId: import.meta.env.VITE_measurementId,
+  guest:'Guest'
 };
 // console.log('From Login: ', firebaseConfig)
 const login = () => {
     store.commit('login')
-    store.commit('changeUser', 'Guest')
+    store.commit('changeUser', firebaseConfig.guest)
     router.push('/')
 }
 </script>


### PR DESCRIPTION
Setting up firebase auth is different to when I did it with cdns and deploying on firebase -- I didn't need to include the apikey in the codebase. 

It is needed when hosting on netlify and building with vite.

In development, 
made .env file with variables as 
VITE_key=random_value
but import.meta.env was available in the console after 
> npm run dev

And the whole of firebaseConfig was available in the Chrome debugger source code 
> npm run build
> npm run serve

ctrl-f for changeUser (used in store.commit) helped me find the right place in the code taken from Login.vue